### PR TITLE
Split security audit into weekly workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,28 +36,3 @@ jobs:
 
       - name: Run unit tests
         run: bats test/talktype.bats
-
-  security:
-    name: Security
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install pip-audit
-        run: pip install pip-audit
-
-      - name: Audit whisper dependencies
-        run: |
-          python3 -m venv /tmp/audit-venv
-          /tmp/audit-venv/bin/pip install --upgrade pip
-          /tmp/audit-venv/bin/pip install faster-whisper
-          /tmp/audit-venv/bin/pip install pip-audit
-          /tmp/audit-venv/bin/pip-audit
-
-      - name: Audit moonshine dependencies
-        run: |
-          python3 -m venv /tmp/audit-moonshine
-          /tmp/audit-moonshine/bin/pip install --upgrade pip
-          /tmp/audit-moonshine/bin/pip install transformers torch soundfile
-          /tmp/audit-moonshine/bin/pip install pip-audit
-          /tmp/audit-moonshine/bin/pip-audit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,28 @@
+name: Security
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 9am UTC
+  pull_request:
+    branches: [main]
+
+jobs:
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Audit whisper dependencies
+        run: |
+          python3 -m venv /tmp/audit-venv
+          /tmp/audit-venv/bin/pip install --upgrade pip
+          /tmp/audit-venv/bin/pip install faster-whisper pip-audit
+          /tmp/audit-venv/bin/pip-audit
+
+      - name: Audit moonshine dependencies
+        run: |
+          python3 -m venv /tmp/audit-moonshine
+          /tmp/audit-moonshine/bin/pip install --upgrade pip
+          /tmp/audit-moonshine/bin/pip install transformers torch soundfile pip-audit
+          /tmp/audit-moonshine/bin/pip-audit


### PR DESCRIPTION
## Summary
- Move pip-audit to its own workflow (weekly + on PRs)
- Main CI (lint + unit tests) stays fast (~30s)
- Branch protection only requires lint + unit tests to merge

## Test plan
- [ ] CI passes on this PR
- [ ] Security workflow triggers on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)