### PR TITLE
CI improvements and comprehensive test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y bats
 
       - name: Install test dependencies
-        run: sudo apt-get install -y ydotool pipewire libnotify-bin
+        run: sudo apt-get install -y ydotool pipewire libnotify-bin socat
 
-      - name: Run unit tests
-        run: bats test/talktype.bats
+      - name: Run tests
+        run: bats test/talktype.bats test/server.bats

--- a/test/mock-daemon.py
+++ b/test/mock-daemon.py
@@ -1,0 +1,36 @@
+"""Mock transcription daemon for testing server mode."""
+import os
+import sys
+import socket
+import signal
+
+SOCK_PATH = sys.argv[1]
+
+def cleanup(*_):
+    try:
+        os.unlink(SOCK_PATH)
+    except OSError:
+        pass
+    sys.exit(0)
+
+signal.signal(signal.SIGTERM, cleanup)
+signal.signal(signal.SIGINT, cleanup)
+
+if os.path.exists(SOCK_PATH):
+    os.unlink(SOCK_PATH)
+
+server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+server.bind(SOCK_PATH)
+server.listen(1)
+
+print("Mock daemon ready.", flush=True)
+
+while True:
+    conn, _ = server.accept()
+    try:
+        audio_path = conn.recv(4096).decode().strip()
+        conn.sendall(b"mock transcription result")
+    except Exception:
+        conn.sendall(b"")
+    finally:
+        conn.close()

--- a/test/mock-transcribe-fail
+++ b/test/mock-transcribe-fail
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Mock transcriber that fails
+echo "error: model not found" >&2
+exit 1

--- a/test/mocks/ffmpeg
+++ b/test/mocks/ffmpeg
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Mock ffmpeg: sleep like a recording process
+# Mock ffmpeg: log that it was called, sleep like a recording process
+echo "ffmpeg" > "$TALKTYPE_DIR/recorder.log"
 trap 'exit 0' TERM
 sleep 300 &
 wait $!

--- a/test/mocks/pw-record
+++ b/test/mocks/pw-record
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Mock pw-record: write PID so tests can clean up, sleep in background
+# Mock pw-record: log that it was called, sleep like a recording process
+echo "pw-record" > "$TALKTYPE_DIR/recorder.log"
 trap 'exit 0' TERM
 sleep 300 &
 wait $!

--- a/test/server.bats
+++ b/test/server.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+# Tests for the server mode (Unix socket daemon pattern).
+# Uses a mock daemon so no real models or venvs are needed.
+
+REPO_DIR="$BATS_TEST_DIRNAME/.."
+
+setup() {
+    export SOCK="$BATS_TEST_TMPDIR/test-server.sock"
+    export PIDFILE="$BATS_TEST_TMPDIR/test-server.pid"
+}
+
+teardown() {
+    # Clean up any leftover daemon
+    if [ -f "$PIDFILE" ]; then
+        kill "$(cat "$PIDFILE")" 2>/dev/null || true
+        rm -f "$PIDFILE"
+    fi
+    rm -f "$SOCK"
+}
+
+# Helper: start the mock daemon
+start_mock_daemon() {
+    python3 "$BATS_TEST_DIRNAME/mock-daemon.py" "$SOCK" &
+    local pid=$!
+    echo "$pid" > "$PIDFILE"
+
+    # Wait for socket to appear
+    for i in $(seq 1 10); do
+        [ -S "$SOCK" ] && return 0
+        sleep 0.1
+    done
+    return 1
+}
+
+# ── Daemon lifecycle ──
+
+@test "mock daemon starts and creates socket" {
+    start_mock_daemon
+
+    [ -S "$SOCK" ]
+    [ -f "$PIDFILE" ]
+    kill -0 "$(cat "$PIDFILE")"
+}
+
+@test "mock daemon responds to transcription requests" {
+    command -v socat &>/dev/null || skip "socat not installed"
+    start_mock_daemon
+
+    result=$(echo "/tmp/test.wav" | socat - UNIX-CONNECT:"$SOCK")
+    [[ "$result" == "mock transcription result" ]]
+}
+
+@test "mock daemon handles multiple requests" {
+    command -v socat &>/dev/null || skip "socat not installed"
+    start_mock_daemon
+
+    result1=$(echo "/tmp/a.wav" | socat - UNIX-CONNECT:"$SOCK")
+    result2=$(echo "/tmp/b.wav" | socat - UNIX-CONNECT:"$SOCK")
+    [[ "$result1" == "mock transcription result" ]]
+    [[ "$result2" == "mock transcription result" ]]
+}
+
+@test "daemon cleans up socket on SIGTERM" {
+    start_mock_daemon
+
+    [ -S "$SOCK" ]
+    kill "$(cat "$PIDFILE")"
+    sleep 0.2
+
+    [ ! -S "$SOCK" ]
+}
+
+# ── Server wrapper logic ──
+
+@test "transcribe fails with helpful message when server not running" {
+    # Test each server script's transcribe command without a running server
+    for server in transcribe-server backends/parakeet-server backends/moonshine-server; do
+        run "$REPO_DIR/$server" transcribe /tmp/test.wav
+        [ "$status" -eq 1 ]
+        [[ "$output" == *"not running"* ]]
+    done
+}
+
+@test "stop reports not running when no pidfile exists" {
+    for server in transcribe-server backends/parakeet-server backends/moonshine-server; do
+        run "$REPO_DIR/$server" stop
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"Not running"* ]]
+    done
+}
+
+@test "invalid subcommand shows usage" {
+    for server in transcribe-server backends/parakeet-server backends/moonshine-server; do
+        run "$REPO_DIR/$server" invalid
+        [ "$status" -eq 1 ]
+        [[ "$output" == *"Usage"* ]]
+    done
+}


### PR DESCRIPTION
## Summary
- Only run CI on pull requests (not redundantly after merge)
- Split security audit into weekly workflow
- Add error handling tests (stale PID, transcription failure)
- Add recorder fallback tests (ffmpeg vs pw-record)
- Add server mode tests (daemon lifecycle, multiple requests, cleanup)
- CI now runs server tests and installs socat

Total: 11 unit tests + 6 server tests + 3 integration tests (local only)

## Test plan
- [ ] CI lint passes
- [ ] All bats tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)