### PR TITLE
Add early development notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Transcription is pluggable — ships with
 [faster-whisper](https://github.com/SYSTRAN/faster-whisper) by default, but you
 can swap in any model or tool that reads audio and prints text.
 
+> **Note:** This project is in early development — expect rough edges. If you
+> run into issues, please [open a bug](https://github.com/csheaff/talktype/issues).
+
 ## Requirements
 
 - Linux (Wayland or X11)


### PR DESCRIPTION
## Summary
- Adds a short callout near the top of the README noting the project is in early development and linking to the issue tracker.

## Test plan
- [x] Verify the note renders correctly in the README markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)