### PR TITLE
Reduce ydotool key-delay to 20ms

### DIFF
--- a/talktype
+++ b/talktype
@@ -97,7 +97,7 @@ if [ -f "$PIDFILE" ]; then
     notify_close
 
     # Type text at cursor via ydotool
-    ydotool type --key-delay 50 -- "$TEXT"
+    ydotool type --key-delay 20 -- "$TEXT"
 
 # ── Otherwise → start recording ──
 else


### PR DESCRIPTION
## Summary
- Lower ydotool key-delay from 50ms to 20ms for faster text output
- Tested on ydotool 0.1.8 without dropped characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)